### PR TITLE
Addition of major landscape in GRUs

### DIFF
--- a/docs/source/configuration.rst
+++ b/docs/source/configuration.rst
@@ -578,6 +578,7 @@ For example:
        "forcing_time_zone": "UTC",  # Time zone of forcing data
        # "model_time_zone": "America/Edmonton",  # Optional: time zone for the model
        "output_path": "results",  # Path to save model outputs relative to model instance's path
+       "landcover_mode": "fractional",  # Method for defining GRUs: "fractional" or "majority"
    }
 
 
@@ -597,6 +598,17 @@ For example:
   of the subbasins.
 
 - ``output_path``: (Optional) Path to save model outputs. Default value is ``results``.
+
+- ``landcover_mode``: (Optional) Method for defining GRUs from landcover data.
+  ``"fractional"`` (default) uses all fractional landcover columns as-is, where
+  each subbasin can have multiple GRUs weighted by area fraction.
+  ``"majority"`` (or ``"mode"``) assigns each subbasin a single GRU
+  corresponding to its dominant landcover class (fraction set to 1.0). When
+  set to ``"majority"`` or ``"mode"``, the input CSV can either contain
+  ``frac_`` columns (the dominant class is computed automatically) or a single
+  ``majority`` / ``mode`` column with the dominant class ID per subbasin.
+  Multiple subbasins may have different dominant classes, so the total number
+  of GRUs can still be greater than one.
 
 
 Class Parameters

--- a/examples/example-setup-python/meshflow_bow_at_calgary.ipynb
+++ b/examples/example-setup-python/meshflow_bow_at_calgary.ipynb
@@ -32,9 +32,9 @@
    "outputs": [],
    "source": [
     "# import necessary libraries\n",
-    "import meshflow # version v0.1.0-dev1\n",
+    "import meshflow\n",
     "\n",
-    "import os # python 3.10.2"
+    "import os"
    ]
   },
   {
@@ -125,6 +125,7 @@
     "            'forcing_time_zone': 'UTC',\n",
     "            # 'model_time_zone': 'America/Edmonton',\n",
     "            'output_path': 'results',\n",
+    "            'landcover_mode': 'fractional',  # change to 'majority' or 'mode' for dominant landcover class\n",
     "        },\n",
     "        'class_params': {\n",
     "            'measurement_heights': {\n",
@@ -221,7 +222,16 @@
    "metadata": {
     "tags": []
    },
-   "outputs": [],
+   "outputs": [
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "/Users/kasrakeshavarz/Documents/github-repos/meshflow/src/meshflow/core.py:497: UserWarning: Landcover mode is set to 'fractional'. GRUs will be defined using fractional landcover columns.\n",
+      "  warnings.warn(\n"
+     ]
+    }
+   ],
    "source": [
     "exp1 = meshflow.MESHWorkflow(**config)"
    ]
@@ -246,11 +256,11 @@
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "/Users/kasrakeshavarz/Documents/github-repos/meshflow/src/meshflow/core.py:898: UserWarning: `maxup` is not a recognized drainage database variable name\n",
+      "/Users/kasrakeshavarz/Documents/github-repos/meshflow/src/meshflow/core.py:959: UserWarning: `maxup` is not a recognized drainage database variable name\n",
       "  warnings.warn(f\"`{k}` is not a recognized drainage database variable name\")\n",
-      "/Users/kasrakeshavarz/Documents/github-repos/meshflow/src/meshflow/core.py:775: UserWarning: Since multiple forcing files are needed, each file will be processed and saved during initialization.\n",
+      "/Users/kasrakeshavarz/Documents/github-repos/meshflow/src/meshflow/core.py:836: UserWarning: Since multiple forcing files are needed, each file will be processed and saved during initialization.\n",
       "  warnings.warn(\n",
-      "/Users/kasrakeshavarz/Documents/github-repos/meshflow/src/meshflow/core.py:1036: UserWarning: Directory /Users/kasrakeshavarz/Documents/github-repos/meshflow/examples/outputs/forcings already exists. Forcing files will be saved there.\n",
+      "/Users/kasrakeshavarz/Documents/github-repos/meshflow/src/meshflow/core.py:1097: UserWarning: Directory /Users/kasrakeshavarz/Documents/github-repos/meshflow/examples/outputs/forcings already exists. Forcing files will be saved there.\n",
       "  warnings.warn(\n",
       "/Users/kasrakeshavarz/Documents/github-repos/meshflow/src/meshflow/utility/forcing_prep.py:138: FutureWarning: The return type of `Dataset.dims` will be changed to return a set of dimension names in future, in order to be more consistent with `DataArray.dims`. To access a mapping from dimension names to lengths, please use `Dataset.sizes`.\n",
       "  var = [i for i in ds.dims.keys() if i != 'time']\n",
@@ -270,25 +280,25 @@
       "  var = [i for i in ds.dims.keys() if i != 'time']\n",
       "/Users/kasrakeshavarz/Documents/github-repos/meshflow/src/meshflow/utility/forcing_prep.py:138: FutureWarning: The return type of `Dataset.dims` will be changed to return a set of dimension names in future, in order to be more consistent with `DataArray.dims`. To access a mapping from dimension names to lengths, please use `Dataset.sizes`.\n",
       "  var = [i for i in ds.dims.keys() if i != 'time']\n",
-      "/Users/kasrakeshavarz/Documents/github-repos/meshflow/src/meshflow/core.py:1584: UserWarning: No `model_time_zone` provided in settings['core']. Autodetecting the time zone using `timezonefinder` based on the centroid of the catchment area.\n",
+      "/Users/kasrakeshavarz/Documents/github-repos/meshflow/src/meshflow/core.py:1645: UserWarning: No `model_time_zone` provided in settings['core']. Autodetecting the time zone using `timezonefinder` based on the centroid of the catchment area.\n",
       "  warnings.warn(\n",
-      "/Users/kasrakeshavarz/Documents/github-repos/meshflow/src/meshflow/core.py:1604: UserWarning: Autodetected model time zone: America/Edmonton\n",
+      "/Users/kasrakeshavarz/Documents/github-repos/meshflow/src/meshflow/core.py:1665: UserWarning: Autodetected model time zone: America/Edmonton\n",
       "  warnings.warn(\n",
-      "/Users/kasrakeshavarz/Documents/github-repos/meshflow/src/meshflow/core.py:1297: UserWarning: GRU 0 not found in landcover classes. Skipping...\n",
+      "/Users/kasrakeshavarz/Documents/github-repos/meshflow/src/meshflow/core.py:1358: UserWarning: GRU 0 not found in landcover classes. Skipping...\n",
       "  warnings.warn(\n",
-      "/Users/kasrakeshavarz/Documents/github-repos/meshflow/src/meshflow/core.py:1297: UserWarning: GRU 3 not found in landcover classes. Skipping...\n",
+      "/Users/kasrakeshavarz/Documents/github-repos/meshflow/src/meshflow/core.py:1358: UserWarning: GRU 3 not found in landcover classes. Skipping...\n",
       "  warnings.warn(\n",
-      "/Users/kasrakeshavarz/Documents/github-repos/meshflow/src/meshflow/core.py:1297: UserWarning: GRU 4 not found in landcover classes. Skipping...\n",
+      "/Users/kasrakeshavarz/Documents/github-repos/meshflow/src/meshflow/core.py:1358: UserWarning: GRU 4 not found in landcover classes. Skipping...\n",
       "  warnings.warn(\n",
-      "/Users/kasrakeshavarz/Documents/github-repos/meshflow/src/meshflow/core.py:1297: UserWarning: GRU 7 not found in landcover classes. Skipping...\n",
+      "/Users/kasrakeshavarz/Documents/github-repos/meshflow/src/meshflow/core.py:1358: UserWarning: GRU 7 not found in landcover classes. Skipping...\n",
       "  warnings.warn(\n",
-      "/Users/kasrakeshavarz/Documents/github-repos/meshflow/src/meshflow/core.py:1297: UserWarning: GRU 9 not found in landcover classes. Skipping...\n",
+      "/Users/kasrakeshavarz/Documents/github-repos/meshflow/src/meshflow/core.py:1358: UserWarning: GRU 9 not found in landcover classes. Skipping...\n",
       "  warnings.warn(\n",
-      "/Users/kasrakeshavarz/Documents/github-repos/meshflow/src/meshflow/core.py:1297: UserWarning: GRU 11 not found in landcover classes. Skipping...\n",
+      "/Users/kasrakeshavarz/Documents/github-repos/meshflow/src/meshflow/core.py:1358: UserWarning: GRU 11 not found in landcover classes. Skipping...\n",
       "  warnings.warn(\n",
-      "/Users/kasrakeshavarz/Documents/github-repos/meshflow/src/meshflow/core.py:1297: UserWarning: GRU 12 not found in landcover classes. Skipping...\n",
+      "/Users/kasrakeshavarz/Documents/github-repos/meshflow/src/meshflow/core.py:1358: UserWarning: GRU 12 not found in landcover classes. Skipping...\n",
       "  warnings.warn(\n",
-      "/Users/kasrakeshavarz/Documents/github-repos/meshflow/src/meshflow/core.py:1297: UserWarning: GRU 13 not found in landcover classes. Skipping...\n",
+      "/Users/kasrakeshavarz/Documents/github-repos/meshflow/src/meshflow/core.py:1358: UserWarning: GRU 13 not found in landcover classes. Skipping...\n",
       "  warnings.warn(\n",
       "/Users/kasrakeshavarz/Documents/github-repos/meshflow/src/meshflow/utility/templating.py:598: UserWarning: Using the Global Water Futures (GWF) default parameter set for class category `needleleaf` with GRU location 0. The parameter set assigned is based on GWF's `needleleaf_defaults` category.\n",
       "  warnings.warn(\"Using the Global Water Futures (GWF) default \"\n",

--- a/src/meshflow/core.py
+++ b/src/meshflow/core.py
@@ -386,6 +386,17 @@ class MESHWorkflow(object):
         # landcover specs
         self.landcover_classes = landcover_classes
 
+        # If settings are provided as a dictionary
+        assert isinstance(settings, dict), "`settings` must be a `dict`"
+        self.settings = settings
+
+        # landcover mode: 'fractional' (default) or 'majority'
+        _lc_mode = self.settings.get('core', {}).get('landcover_mode', 'fractional')
+        if _lc_mode not in ('fractional', 'majority', 'mode'):
+            raise ValueError("`settings['core']['landcover_mode']` must be "
+                             "either 'fractional' or 'majority' (or 'mode')")
+        self.landcover_mode = _lc_mode
+
         # assing inputs read from files
         self._read_input_files()
 
@@ -398,10 +409,6 @@ class MESHWorkflow(object):
         # MESH-specific variables
         self.rank_str = 'Rank'
         self.next_str = 'Next'
-
-        # If settings are provided as a dictionary
-        assert isinstance(settings, dict), "`settings` must be a `dict`"
-        self.settings = settings
 
     def _read_input_files(self):
         """
@@ -441,11 +448,19 @@ class MESHWorkflow(object):
         """
         Reads and returns the landcover DataFrame for catchments present in the input domain.
 
+        When ``self.landcover_mode`` is ``'fractional'``, all ``frac_`` columns
+        are returned as-is. When ``'majority'`` or ``'mode'``, each subbasin
+        is assigned a single GRU corresponding to its dominant landcover
+        class (fraction = 1.0). The dominant class is determined either from
+        a ``majority`` / ``mode`` column in the CSV (if present and no
+        ``frac_`` columns exist) or by computing ``idxmax`` across the
+        ``frac_`` columns.
+
         Returns
         -------
         pd.DataFrame
-            Landcover fractions for each catchment, filtered to include only those
-            present in the catchment file and only columns starting with 'frac_'.
+            Landcover fractions for each catchment, with columns named
+            ``frac_<class_id>``.
         """
 
         # [FIXME]: This needs to be flexible in future versions
@@ -478,7 +493,53 @@ class MESHWorkflow(object):
         _rows = [row for row in _lc_df.index if _seg_ids.isin([row]).any()]
         _cols = [col for col in _lc_df.columns if
                  col.startswith(_lc_prefix)]
- 
+
+        warnings.warn(
+            f"Landcover mode is set to '{self.landcover_mode}'. "
+            f"GRUs will be defined using "
+            f"{'fractional landcover columns' if self.landcover_mode == 'fractional' else 'the dominant (majority) landcover class per subbasin'}.",
+            UserWarning,
+        )
+
+        if self.landcover_mode in ('majority', 'mode'):
+            # Case 1: CSV has only a 'majority' or 'mode' column (no frac_ columns)
+            if not _cols:
+                _mode_col = None
+                for candidate in ('majority', 'mode'):
+                    if candidate in _lc_df.columns:
+                        _mode_col = candidate
+                        break
+                if _mode_col is None:
+                    raise ValueError(
+                        "landcover_mode is set to 'majority'/'mode' but the "
+                        "CSV has neither 'frac_' columns nor a 'majority'/"
+                        "'mode' column"
+                    )
+                # read the dominant class per subbasin from the column
+                dominant = _lc_df.loc[_rows, _mode_col]
+            else:
+                # Case 2: CSV has frac_ columns — compute dominant from them
+                _lc_filtered = _lc_df.loc[_rows, _cols].copy()
+                dominant = _lc_filtered.idxmax(axis=1)
+
+            # normalize dominant values to 'frac_<id>' format
+            dominant = dominant.apply(
+                lambda v: v if str(v).startswith(_lc_prefix)
+                else f'{_lc_prefix}{v}'
+            )
+
+            # get unique dominant classes
+            unique_classes = sorted(dominant.unique())
+
+            # build new DataFrame: 1.0 for dominant class, 0.0 otherwise
+            _lc_majority = pd.DataFrame(
+                0.0, index=dominant.index, columns=unique_classes,
+            )
+            for idx, dom_class in dominant.items():
+                _lc_majority.loc[idx, dom_class] = 1.0
+
+            return _lc_majority
+
         # return a copy of the dataframe including hrus available in the
         # input domain and only fractions
         return _lc_df.loc[_rows, _cols].copy()


### PR DESCRIPTION
This pull request adds support for a new `landcover_mode` configuration option (addressing issue #46), allowing users to specify how GRUs (Group Response Units) are defined from landcover data—either using all fractional columns or by assigning each subbasin a single dominant landcover class. The documentation and example notebook are updated to reflect this new feature, and the core logic in `core.py` is extended to handle both modes.

**New Feature: Landcover Mode Selection**
- Added `landcover_mode` option to configuration, allowing selection between `"fractional"` (default) and `"majority"`/`"mode"` methods for defining GRUs from landcover data. [[1]](diffhunk://#diff-e662b6389537d2a309e93ca2065f311d3f00156764a4835671300f6c4e95ec1dR581) [[2]](diffhunk://#diff-e662b6389537d2a309e93ca2065f311d3f00156764a4835671300f6c4e95ec1dR602-R612) [[3]](diffhunk://#diff-dacf7fae9436453c8f447bf54da7f3f62f75e7ad40cd64bc44b9682360021640R128) [[4]](diffhunk://#diff-b8e5a52c75da2545c832931a465a785ffda88c2b0b50df94a04850f9bc26abedR389-R399)

**Core Logic Updates**
- Updated `MESHWorkflow` initialization and `_read_landcover` method in `core.py` to support both fractional and majority/mode landcover assignment, including validation and construction of the appropriate landcover DataFrame. [[1]](diffhunk://#diff-b8e5a52c75da2545c832931a465a785ffda88c2b0b50df94a04850f9bc26abedR389-R399) [[2]](diffhunk://#diff-b8e5a52c75da2545c832931a465a785ffda88c2b0b50df94a04850f9bc26abedR451-R463) [[3]](diffhunk://#diff-b8e5a52c75da2545c832931a465a785ffda88c2b0b50df94a04850f9bc26abedR497-R542)

**Documentation and Example Improvements**
- Improved documentation in `configuration.rst` to explain the new `landcover_mode` option and its usage.
- Updated the example notebook to demonstrate usage of the new option and to reflect changes in warnings and output. [[1]](diffhunk://#diff-dacf7fae9436453c8f447bf54da7f3f62f75e7ad40cd64bc44b9682360021640R128) [[2]](diffhunk://#diff-dacf7fae9436453c8f447bf54da7f3f62f75e7ad40cd64bc44b9682360021640L224-R234)

**Other Minor Updates**
- Adjusted warning messages and line numbers in the example notebook to match code changes. [[1]](diffhunk://#diff-dacf7fae9436453c8f447bf54da7f3f62f75e7ad40cd64bc44b9682360021640L249-R263) [[2]](diffhunk://#diff-dacf7fae9436453c8f447bf54da7f3f62f75e7ad40cd64bc44b9682360021640L273-R301)
- Minor cleanup in import statements in the example notebook.